### PR TITLE
changes to add MMDebug to PicoMite firmware

### DIFF
--- a/PicoMite/CMakeLists.txt
+++ b/PicoMite/CMakeLists.txt
@@ -11,6 +11,8 @@ add_executable(PicoMite
     MMBasic.c
     Operators.c
     Custom.c
+    Debugger.c
+    Debugger-misc.c
     Functions.c
     Commands.c
     Memory.c

--- a/PicoMite/Debugger-misc.c
+++ b/PicoMite/Debugger-misc.c
@@ -1,0 +1,776 @@
+/***********************************************************************************************************************
+PicoMite MMBasic
+
+Memory.c
+
+<COPYRIGHT HOLDERS>  E. David Neufeld
+Copyright (c) 2023, <COPYRIGHT HOLDERS> All rights reserved.
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following
+conditions are met: 1.	Redistributions of source code must retain the above copyright notice, this list of conditions and the
+following disclaimer.
+2.	Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+disclaimer in the documentation and/or other materials provided with the distribution.
+3.	The name MMBasic be used when referring to the interpreter in any documentation and promotional material and the original
+copyright message be displayed on the console at startup (additional copyright messages may be added). 4.	All advertising
+materials mentioning features or use of this software must display the following acknowledgement: This product includes software
+developed by the <copyright holder>. 5.	Neither the name of the <copyright holder> nor the names of its contributors may be used
+to endorse or promote products derived from this software without specific prior written permission. THIS SOFTWARE IS PROVIDED BY
+<COPYRIGHT HOLDERS> AS IS AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDERS> BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+************************************************************************************************************************/
+
+#define INCLUDE_FUNCTION_DEFINES
+
+#include "Hardware_Includes.h"
+#include "MMBasic_Includes.h"
+#include "Debugger.h"
+#include "class/cdc/cdc_device.h"
+
+#ifdef PICOMITEVGA
+#endif
+
+#ifdef PICOMITE
+#endif
+
+#ifdef PICOMITEWEB
+#endif
+
+//
+//
+// The user needs to do > Option Display 45,145
+//                      > Option Colourcode On
+//
+// prior to using this debugger.....
+//
+//
+extern int
+    debugger_scrn_x_column; // Actually not the 'size'  Instead, it is the column position for the start of the debugger area
+extern int debugger_scrn_y_size;
+extern int Mouse_X, Mouse_Y;
+
+char TeraTerm_active = 0;
+
+void printLine(int);
+void SetColour(unsigned char *, int);
+char *findLine(int);
+
+unsigned char *LocateProgramStatement(int line) {
+   unsigned char *p, *previous_stmt;
+   int cnt = 0;
+
+   previous_stmt = p = ProgMemory;
+
+   while (1) {
+      if (*p == 0xff || (p[0] == 0 && p[1] == 0)) // end of the program
+         return NULL;
+
+      if (*p == T_NEWLINE) {
+         previous_stmt = p;
+         p++; // and step over the new line marker
+         cnt++;
+         if (cnt >= line)
+            return previous_stmt;
+         continue;
+      }
+      if (*p == T_LINENBR) {
+         p += 3; // and step over the line number
+         continue;
+      }
+      if (*p == T_LABEL) {
+         p += p[0] + 2; // still looking! skip over the label
+         continue;
+      }
+      p++;
+   }
+   return NULL;
+}
+
+short int dbg_next_chars[N_DEBUG_UNGETCHAR] = {[0 ... N_DEBUG_UNGETCHAR - 1] = -1};
+
+void Debugger_unget_char(int c) {
+   int i;
+
+   for (i = N_DEBUG_UNGETCHAR - 2; i > 0; i--)
+      dbg_next_chars[i + 1] = dbg_next_chars[i];
+
+   dbg_next_chars[0] = c;
+}
+
+int Debugger_input_pending() {
+   int c;
+
+   if (dbg_next_chars[0] != -1)
+      return true;
+
+   c = tud_cdc_read_char();
+   if (c == -1)     // if there is nothing in the 'unget' buffer and calling tud_cdc_read_char() returns
+      return false; // nothing, we can tell the caller that no input is pending.
+
+   Debugger_unget_char(c);
+
+   return true;
+}
+
+int Debugger_get_char() {
+   int c, i;
+
+   if (dbg_next_chars[0] != -1) {
+      c = dbg_next_chars[0];
+      for (i = 0; i < N_DEBUG_UNGETCHAR - 2; i++)
+         dbg_next_chars[i] = dbg_next_chars[i + 1];
+      dbg_next_chars[N_DEBUG_UNGETCHAR - 1] = -1;
+
+      return c;
+   }
+   c = tud_cdc_read_char();
+
+   return c;
+}
+
+int Debugger_getc(void) {
+   int c, c1, c2;
+
+   while ((c = Debugger_get_char()) == -1)
+      ;
+
+   if (c != 0x1b) /* if not an escape sequence, we just return the character */
+      return c;
+
+   InkeyTimer = 0;
+   while ((c = tud_cdc_read_char()) == -1 && InkeyTimer < 40) /* get 2nd character of sequence */
+      ;
+   if (c == -1)
+      return -1;
+
+   if (c != '[') // must be a square bracket
+      return -1;
+
+   while ((c = tud_cdc_read_char()) == -1 && InkeyTimer < 90)
+      ; // get the third char with delay
+   if (c == -1)
+      return -1;
+
+   if (c == 'A')
+      return UP; // the arrow keys are three chars
+   if (c == 'B')
+      return DOWN;
+   if (c == 'C')
+      return RIGHT;
+   if (c == 'D')
+      return LEFT;
+
+   if (c == 'M') { // We have a Mouse Cursor Position report coming!
+      while ((c = tud_cdc_read_char()) == -1 && InkeyTimer < 120)
+         ; // get the 4th char which should be a space
+
+      if (TeraTerm_active == 0 && c == '#') {                          // The first time MMDebug sees ESC [ M # the remaining
+         TeraTerm_active = 1;                                          // characters of the sequence need to be ate.   The reason
+         while ((c = tud_cdc_read_char()) == -1 && InkeyTimer < 140)   // is the Mouse Click Down has already been seen and sent
+            ;                                                          // to the command processor.   We don't want a double click on
+         while ((c = tud_cdc_read_char()) == -1 && InkeyTimer < 160)   // what ever the user is pointing at.
+            ;
+         return -1;
+      }
+
+      if (TeraTerm_active == 1 && c == ' ') {                          // If TeraTerm has been detected, we don't alow the
+         while ((c = tud_cdc_read_char()) == -1 && InkeyTimer < 140)   // mouse click down to be reported.   The reason is the
+            ;                                                          // mouse click up will generate noise if the user has an
+         while ((c = tud_cdc_read_char()) == -1 && InkeyTimer < 160)   // input statement active.
+            ;       
+         return -1;
+      }
+
+      while ((c = tud_cdc_read_char()) == -1 && InkeyTimer < 140)
+         ; // get the 5th char which should be the X coordinate
+      if (c == -1)
+         return -1;
+      Mouse_X = c - 32;
+
+      while ((c = tud_cdc_read_char()) == -1 && InkeyTimer < 160)
+         ; // get the 6th char which should be the Y coordinate
+      if (c == -1)
+         return -1;
+      Mouse_Y = c - 32;
+
+      //----------------------------------------------------------------------------------------------
+      //------ Check if any of the command buttons have been clicked on the Prompt Line       --------
+      //------ at the bottom of the screen.   If so, return the proper ascii code             --------
+      //----------------------------------------------------------------------------------------------
+      if (Mouse_Y >= debugger_scrn_y_size) // the user clicked too low on the screen.
+         return MOUSE_CLICK;               // out of the debug window
+
+      if (Mouse_X >= DBG_X_COLUMN + DBG_BUTTON_PAGE_UP) { // check if it can be a Page-Up
+         if (Mouse_Y >= debugger_scrn_y_size - 5 && Mouse_Y <= debugger_scrn_y_size - 4)
+            return PUP;
+      }
+
+      if (Mouse_X >= DBG_X_COLUMN + DBG_BUTTON_PAGE_DOWN) { // check if it can be a Page-Down
+         if (Mouse_Y >= debugger_scrn_y_size - 2 && Mouse_Y <= debugger_scrn_y_size - 1)
+            return PDOWN;
+      }
+
+      if (Mouse_X >= DBG_X_COLUMN + DBG_BUTTON_LINE_UP) { // check if it can be a Line-Up
+         if (Mouse_Y >= debugger_scrn_y_size - 5 && Mouse_Y <= debugger_scrn_y_size - 4)
+            return UP;
+      }
+
+      if (Mouse_X >= DBG_X_COLUMN + DBG_BUTTON_LINE_DOWN) { // check if it can be a Line-Down
+         if (Mouse_Y >= debugger_scrn_y_size - 2 && Mouse_Y <= debugger_scrn_y_size - 1)
+            return DOWN;
+      }
+
+      //----------------------------------------------------------------------------------------------
+      //------ Done checking for Page Up/Down buttons and Line Up/Down buttons                --------
+      //------                                                                                --------
+      //------ Now check for Step buttons                                                     --------
+      //----------------------------------------------------------------------------------------------
+
+      if (Mouse_X >= DBG_X_COLUMN + DBG_BUTTON_STEP &&
+          Mouse_X <= DBG_X_COLUMN + DBG_BUTTON_STEP + 5) {      // check if it can be a Step
+         if (Mouse_Y >= debugger_scrn_y_size - 2 && Mouse_Y <= debugger_scrn_y_size - 1)
+            return STEP;
+      }
+
+      if (Mouse_X >= DBG_X_COLUMN + DBG_BUTTON_STEP_OVER &&
+          Mouse_X <= DBG_X_COLUMN + DBG_BUTTON_STEP_OVER + 5) { // check if it can be a Step-Over
+         if (Mouse_Y >= debugger_scrn_y_size - 2 && Mouse_Y <= debugger_scrn_y_size - 1)
+            return STEP_OVER;
+      }
+
+      if (Mouse_X >= DBG_X_COLUMN + DBG_BUTTON_STEP_OUT &&
+          Mouse_X <= DBG_X_COLUMN + DBG_BUTTON_STEP_OUT + 5) {  // check if it can be a Step-Out
+         if (Mouse_Y >= debugger_scrn_y_size - 2 && Mouse_Y <= debugger_scrn_y_size - 1)
+            return STEP_OUT;
+      }
+
+      if (Mouse_X >= DBG_X_COLUMN + DBG_BUTTON_GO &&
+          Mouse_X <= DBG_X_COLUMN + DBG_BUTTON_GO + 4) {        // check if it can be a Go command
+         if (Mouse_Y >= debugger_scrn_y_size - 2 && Mouse_Y <= debugger_scrn_y_size - 1)
+            return GO;
+      }
+
+      if (Mouse_X >= DBG_X_COLUMN + DBG_BUTTON_QUIT &&
+	  Mouse_X <= DBG_X_COLUMN + DBG_BUTTON_QUIT + 4) {      // check if it can be a Quit command
+         if (Mouse_Y >= debugger_scrn_y_size - 2 && Mouse_Y <= debugger_scrn_y_size - 1)
+            return QUIT;
+      }
+
+      //---------------------------------------------------------------------------------------------------------------------
+      //------ Done checking for Step commands.  Now check for Display-Variable and 'Set Break Point & Go' command   --------
+      //---------------------------------------------------------------------------------------------------------------------
+
+      if (Mouse_X >= DBG_X_COLUMN + DBG_BUTTON_EDIT_VALUE &&
+          Mouse_X <= DBG_X_COLUMN + DBG_BUTTON_EDIT_VALUE + 6) { // check if it can be a Edit Value
+         if (Mouse_Y >= debugger_scrn_y_size - 2 && Mouse_Y <= debugger_scrn_y_size - 1)
+            return EDIT_VALUE;
+      }
+
+      if (Mouse_X >= DBG_X_COLUMN && Mouse_X <= DBG_X_COLUMN + 5) {
+         if (Mouse_Y >= 1 && Mouse_Y <= debugger_scrn_y_size - 5)
+            return BRK_PNT_and_GO;
+      }
+
+      return MOUSE_CLICK;
+   }
+
+   if (c < '1' && c > '6') // 3rd character must be ascii 1 to 6
+      return -1;
+
+   while ((c1 = tud_cdc_read_char()) == -1 && InkeyTimer < 100) // get the fourth char
+      ; 
+   if (c1 == -1)
+      return -1;
+
+   if (c1 == '~') { // all 4 char codes must be terminated with ~
+      if (c == '1')
+         return HOME;
+      if (c == '2')
+         return INSERT;
+      if (c == '3')
+         return DEL;
+      if (c == '4')
+         return END;
+      if (c == '5')
+         return PUP;
+      if (c == '6')
+         return PDOWN;
+      return -1;
+   }
+
+   while ((c2 = tud_cdc_read_char()) == -1 && InkeyTimer < 110) // get the fifth char
+      ;
+   if (c2 == -1)
+      return -1;
+
+   if (c2 == '~') { // must be a ~
+      if (c == '1') {
+         if (c1 >= '1' && c1 <= '5')
+            return F1 + (c1 - '1'); // F1 to F5
+         if (c1 >= '7' && c1 <= '9')
+            return F6 + (c1 - '7'); // F6 to F8
+      }
+      if (c == '2') {
+         if (c1 == '0' || c1 == '1')
+            return F9 + (c1 - '0'); // F9  or F10
+         if (c1 == '3' || c1 == '4')
+            return F11 + (c1 - '3'); // F11 or F12
+      }
+   }
+   return -1;
+}
+
+void Debugger_getline(char *buff) {
+   int c;
+   char *ptr;
+
+   ptr = buff;
+   *ptr = 0;
+
+   while (1) {
+      while ((c = Debugger_getc()) == -1) // wait for a character
+         ;
+      if (c == '\n' || c == '\r')
+         return;
+
+      if (c == MOUSE_CLICK) { // the user doesn't want to keep typing.
+         ptr = buff;          // they clicked somewhere on the screen
+         *ptr = MOUSE_CLICK;
+         *ptr++ = 0;
+         //			Debugger_unget_char( c);
+         {
+            char str[50];
+            VT100_goto_xy(60, debugger_scrn_y_size);
+            VT100_forground_red();
+            VT100_background_yellow();
+            MMPrintString(" (");
+            IntToStr(str, Mouse_X, 10);
+            MMPrintString(str);
+            MMPrintString(",");
+            IntToStr(str, Mouse_Y, 10);
+            MMPrintString(str);
+            MMPrintString(") ");
+            VT100_background_black();
+            VT100_forground_white();
+            Debugger_Pause(1500);
+         }
+
+         return;
+      }
+
+      if (c == '\b') { // handle the backspace
+         if (ptr > buff) {
+            MMPrintString("\b \b");
+            ptr--;
+            *ptr = 0;
+         }
+         continue;
+      }
+      if ((ptr - buff) < 60) { // even an 60 character line is excessive for line size
+         *ptr++ = c;           // that the debugger needs from the user.
+         *ptr = 0;
+         MMputchar(c, 1); // and echo the character so the user can see what they typed
+      }
+   }
+}
+
+void VT100_Clear_Debugger_Screen() {
+   int i;
+
+   VT100_forground_cyan();
+   for (i = 1; i < debugger_scrn_y_size; i++) {
+      VT100_goto_xy(debugger_scrn_x_column, i);
+      VT100_Clear_to_EOL();
+      MMPrintString("|");
+   }
+
+   VT100_goto_xy(debugger_scrn_x_column, debugger_scrn_y_size);
+
+   for (i = 1; i < 145 - debugger_scrn_x_column + 2; i++) {
+      MMPrintString("_");
+   }
+
+   VT100_forground_white();
+}
+
+void Debugger_Prompt() {
+
+   VT100_forground_white();
+   VT100_background_red();
+
+   VT100_goto_xy(debugger_scrn_x_column + DBG_BUTTON_LINE_UP, debugger_scrn_y_size - 5);
+   MMPrintString(" Line ");
+   VT100_goto_xy(debugger_scrn_x_column + DBG_BUTTON_LINE_UP, debugger_scrn_y_size - 4);
+   MMPrintString("  UP  ");
+
+   VT100_goto_xy(debugger_scrn_x_column + DBG_BUTTON_LINE_DOWN, debugger_scrn_y_size - 2);
+   MMPrintString(" Line ");
+   VT100_goto_xy(debugger_scrn_x_column + DBG_BUTTON_LINE_DOWN, debugger_scrn_y_size - 1);
+   MMPrintString(" DOWN ");
+
+   VT100_goto_xy(debugger_scrn_x_column + DBG_BUTTON_PAGE_UP, debugger_scrn_y_size - 5);
+   MMPrintString(" Page ");
+   VT100_goto_xy(debugger_scrn_x_column + DBG_BUTTON_PAGE_UP, debugger_scrn_y_size - 4);
+   MMPrintString("  UP  ");
+
+   VT100_goto_xy(debugger_scrn_x_column + DBG_BUTTON_PAGE_DOWN, debugger_scrn_y_size - 2);
+   MMPrintString(" Page ");
+   VT100_goto_xy(debugger_scrn_x_column + DBG_BUTTON_PAGE_DOWN, debugger_scrn_y_size - 1);
+   MMPrintString(" DOWN ");
+
+   VT100_goto_xy(debugger_scrn_x_column + DBG_BUTTON_STEP, debugger_scrn_y_size - 2);
+   MMPrintString(" Step ");
+   VT100_goto_xy(debugger_scrn_x_column + DBG_BUTTON_STEP, debugger_scrn_y_size - 1);
+   MMPrintString("      ");
+
+   VT100_goto_xy(debugger_scrn_x_column + DBG_BUTTON_STEP_OVER, debugger_scrn_y_size - 2);
+   MMPrintString(" Step ");
+   VT100_goto_xy(debugger_scrn_x_column + DBG_BUTTON_STEP_OVER, debugger_scrn_y_size - 1);
+   MMPrintString(" Over ");
+
+   VT100_goto_xy(debugger_scrn_x_column + DBG_BUTTON_STEP_OUT, debugger_scrn_y_size - 2);
+   MMPrintString(" Step ");
+   VT100_goto_xy(debugger_scrn_x_column + DBG_BUTTON_STEP_OUT, debugger_scrn_y_size - 1);
+   MMPrintString(" Out  ");
+
+   VT100_goto_xy(debugger_scrn_x_column + DBG_BUTTON_GO, debugger_scrn_y_size - 2);
+   MMPrintString("    ");
+   VT100_goto_xy(debugger_scrn_x_column + DBG_BUTTON_GO, debugger_scrn_y_size - 1);
+   MMPrintString(" GO ");
+
+   VT100_goto_xy(debugger_scrn_x_column + DBG_BUTTON_QUIT, debugger_scrn_y_size - 2);
+   MMPrintString("      ");
+   VT100_goto_xy(debugger_scrn_x_column + DBG_BUTTON_QUIT, debugger_scrn_y_size - 1);
+   MMPrintString(" Quit ");
+
+   VT100_goto_xy(debugger_scrn_x_column + DBG_BUTTON_EDIT_VALUE, debugger_scrn_y_size - 2);
+   MMPrintString(" Edit  ");
+   VT100_goto_xy(debugger_scrn_x_column + DBG_BUTTON_EDIT_VALUE, debugger_scrn_y_size - 1);
+   MMPrintString(" Value ");
+}
+
+void VT100_goto_xy(int x, int y) { // Move cursor to screen's (x,y) coordinates.   x & y are 1 based.
+   char s[12];
+
+   MMPrintString("\033[");
+   IntToStr(s, y, 10);
+   MMPrintString(s);
+   MMPrintString(";");
+   IntToStr(s, x, 10);
+   MMPrintString(s);
+   MMPrintString("H");
+}
+
+void setup_terminal_screen_to_145x45(void) {
+   char tmp[30] = {0};
+   MMPrintString("\033[8;");
+   IntToStr(tmp, 45, 10);
+   strcat(tmp, ";");
+   MMPrintString(tmp);
+   IntToStr(tmp, 145, 10);
+   strcat(tmp, "t");
+   MMPrintString(tmp);
+}
+
+void VT100_Mouse_Mode_On() { MMPrintString("\033[?1000h"); }
+void VT100_Clear_Screen() { MMPrintString("\033[2J2J"); }
+void VT100_Clear_to_EOL() { MMPrintString("\033[K"); } // clear to the end of the line on a vt100 emulator
+void VT100_all_attr_off() { MMPrintString("\033[m"); }
+void VT100_bold_on() { MMPrintString("\033[1m"); }
+void VT100_low_intensity() { MMPrintString("\033[2m"); }
+void VT100_underline_on() { MMPrintString("\033[4m"); }
+void VT100_save_cursor() { MMPrintString("\0337"); }
+void VT100_restore_cursor() { MMPrintString("\0338"); }
+void VT100_forground_black() { MMPrintString("\033[30m"); }
+void VT100_forground_red() { MMPrintString("\033[31m"); }
+void VT100_forground_green() { MMPrintString("\033[32m"); }
+void VT100_forground_yellow() { MMPrintString("\033[33m"); }
+void VT100_forground_blue() { MMPrintString("\033[34m"); }
+void VT100_forground_cyan() { MMPrintString("\033[36m"); }
+void VT100_forground_magenta() { MMPrintString("\033[35m"); }
+void VT100_forground_white() { MMPrintString("\033[37m"); }
+void VT100_forground_grey() { MMPrintString("\033[90m"); }
+
+void VT100_background_black() { MMPrintString("\033[40m"); }
+void VT100_background_red() { MMPrintString("\033[41m"); }
+void VT100_background_green() { MMPrintString("\033[42m"); }
+void VT100_background_yellow() { MMPrintString("\033[43m"); }
+void VT100_background_blue() { MMPrintString("\033[44m"); }
+void VT100_background_cyan() { MMPrintString("\033[46m"); }
+void VT100_background_magenta() { MMPrintString("\033[45m"); }
+void VT100_background_white() { MMPrintString("\033[47m"); }
+void VT100_background_grey() { MMPrintString("\033[100m"); }
+
+void Debug_Info(char *title, int value) {
+   char tmp[100];
+
+   MMPrintString(title);
+   IntToStr(tmp, value, 10);
+   MMPrintString(tmp);
+}
+
+void Debug_Info_hex(char *title, int value) {
+   char tmp[100];
+
+   MMPrintString(title);
+   IntToStr(tmp, value, 16);
+
+   if (strlen(tmp) < 2)
+      MMPrintString("0");
+
+   MMPrintString(tmp);
+}
+
+void Debug_Info_char(char *title, unsigned char value) {
+   char tmp[10];
+
+   MMPrintString(title);
+   tmp[0] = value;
+   tmp[1] = 0;
+   MMPrintString(tmp);
+}
+
+void Debugger_var_display() {
+   int i, j, l, nl, avail, vi;
+   union u_val *uv_ptr;
+   unsigned char c;
+   char disp[40];
+   void *ptr;
+
+   for (i = 0; i < n_disp_elements; i++) {
+      VT100_goto_xy(DBG_VAR_COLUMN, i + 1);
+      VT100_all_attr_off();
+      VT100_Clear_to_EOL(); // first we put the variable's name in place
+      VT100_forground_cyan();
+      MMPrintString("|");
+      VT100_forground_yellow();
+
+      strcpy(disp, (char *)var_disp_list[i].name);
+      if (strlen(disp) > 10) {
+         VT100_underline_on(); // if we can't display the entire variable name, we underline it
+         disp[11] = 0;         // so the user knows some information is missing
+      }
+
+      l = strlen((char *)var_disp_list[i].name);
+      c = var_disp_list[i].name[l];
+
+      if (c == '!')
+         ptr = findvar(var_disp_list[i].name, V_NOFIND_NULL | T_IMPLIED | T_NBR);
+      else if (c == '$')
+         ptr = findvar(var_disp_list[i].name, V_NOFIND_NULL | T_IMPLIED | T_STR);
+      else if (c == '%')
+         ptr = findvar(var_disp_list[i].name, V_NOFIND_NULL | T_IMPLIED | T_INT);
+      else
+
+         ptr = findvar(var_disp_list[i].name, V_NOFIND_NULL);
+
+      if (ptr == NULL) {
+         for (j = i; j < n_disp_elements - 1; j++)
+            var_disp_list[j] = var_disp_list[j + 1];
+         n_disp_elements--;
+         i--;
+         continue;
+      }
+
+      vi = VarIndex;
+
+      MMPrintString(disp);
+      nl = strlen(disp);
+
+      VT100_all_attr_off();
+      VT100_goto_xy(DBG_VAR_VAL_COLUMN, i + 1); // now we attempt to display the value of the variable
+
+      /*
+                      if (ptr == NULL)  {
+                              VT100_background_red();
+                              MMPrintString("   ?   ");
+                              VT100_background_black();
+                      } else {
+      */
+      if (vartbl[vi].type & T_PTR)                  // Get a pointer to what ever value we are going
+         uv_ptr = (union u_val *)vartbl[vi].val.ia; // to display.   If this is a ptr to another variable,
+      else                                          // we dereference it before continueing.
+         uv_ptr = &vartbl[vi].val;
+
+      switch (vartbl[vi].type & (T_NOTYPE | T_STR | T_INT | T_NBR)) {
+      case T_NBR:
+         VT100_forground_green();
+         if (var_disp_list[i].val.f != uv_ptr->f) { // check if the variable's value has changed
+            VT100_forground_red();
+            var_disp_list[i].val.f = uv_ptr->f;
+         }
+         FloatToStr(disp, uv_ptr->f, 5, 2, ' ');
+         disp[10] = 0;
+         MMPrintString(disp);
+         break;
+
+      case T_INT:
+         VT100_forground_green();
+         if (var_disp_list[i].val.i != uv_ptr->i) { // check if the variable's value has changed
+            VT100_forground_red();
+            var_disp_list[i].val.i = uv_ptr->i;
+         }
+         IntToStr(disp, uv_ptr->i, 10);
+         VT100_goto_xy( 145 - 2 - strlen(disp) , i + 1); // line up integers so they are positioned the
+         MMPrintString(disp);                            // same as the mantisa for real numbers
+         break;
+
+      case T_STR:
+         VT100_forground_magenta();
+         if (var_disp_list[i].val.s != uv_ptr->s) { // check if the storage area for the variable
+            VT100_forground_red();                  // has changed.   Note that this doesn't necessarily
+            var_disp_list[i].val.s = uv_ptr->s;     // mean the value has changed.  Just the storage
+         }                                          // allocated to hold it has changed.
+         strncpy(disp, (char *)&uv_ptr->s[1], 35);
+         l = uv_ptr->s[0]; // chop off the string at an appropriate length
+         if (l > sizeof(disp))
+            l = sizeof(disp) - 1;
+         disp[l] = 0;
+         avail = 145 - (DBG_VAR_COLUMN + nl);
+         if (l < avail) { // plenty of space, right justify the entire string
+            VT100_goto_xy(145 - l + 1, i + 1);
+            MMPrintString(disp);
+         } else {
+            VT100_goto_xy(145 - avail + 2, i + 1); // leave a space between name and str value
+            VT100_underline_on();                  // if we can't display the entire string, we want
+            VT100_forground_magenta();
+            disp[avail] = 0; // to caution the user some of it is not shown
+            MMPrintString(disp);
+         }
+         break;
+
+      case T_NOTYPE:
+         MMPrintString("No Type");
+         break;
+
+      default:
+         VT100_forground_red();
+         MMPrintString("? Huh ?");
+         break;
+         //			}
+
+         VT100_forground_yellow();
+         VT100_background_black();
+      }
+   }
+}
+
+// count the number of lines up to and including the line pointed to by the argument
+// used for error reporting in programs that do not use line numbers.
+//
+// This code was stolen from MMBasic.c   The hackery to not count the title comment at the
+// start of the program causes a lot of inconsistancy.   It is a small function so it is
+// cleaner to just duplicate it here and use this version within the Debugger.
+//
+// I think the MMBasic Trace command should just include the first (title) line in its count.
+// But in the mean time...   We duplicate the functionality here:
+
+int Debug_CountLines(unsigned char *target) {
+   unsigned char *p;
+   int cnt;
+
+   p = ProgMemory;
+   cnt = 0;
+
+   //  if(ProgMemory[0]==1 && ProgMemory[1]==39 && ProgMemory[2]==35)cnt=-1;		// Remove the hackery that makes everything
+   //  inconsistent
+   //  else cnt = 0;									// depending on whether the user put a title line at the
+   //  start.
+
+   while (1) {
+      if (*p == 0xff || (p[0] == 0 && p[1] == 0)) // end of the program
+         return cnt;
+
+      if (*p == T_NEWLINE) {
+         p++; // and step over the line number
+         cnt++;
+         if (p >= target)
+            return cnt;
+         continue;
+      }
+
+      if (*p == T_LINENBR) {
+         p += 3; // and step over the line number
+         continue;
+      }
+
+      if (*p == T_LABEL) {
+         p += p[0] + 2; // still looking! skip over the label
+         continue;
+      }
+
+      if (p++ > target)
+         return cnt;
+   }
+   return cnt;
+}
+
+void Debugger_find_special_cmds() {
+
+   Rem_cmd = GetCommandValue((unsigned char *)"Rem");
+   Return_cmd = GetCommandValue((unsigned char *)"Return");
+   GoTo_cmd = GetCommandValue((unsigned char *)"GoTo");
+   On_cmd = GetCommandValue((unsigned char *)"On");
+}
+
+void ClearDebugger() {
+   int i;
+
+   n_disp_elements = 0;
+
+   MMDebug_Brk_Pnt_Addr = NULL; // We don't clear the MMDebug flag because ClearDebugger() only gets called from the
+                                // MMBasic cmd_run() function.   At that point, the user has typed 'RUN' and may have
+                                // requested the debugger to take control.   If Ctrl-D has been typed, and captured by
+                                // the MMDebug flag, we want that to stay active.
+
+   for (i = 0; i < DISPLAY_LIST_SIZE; i++) {
+      var_disp_list[i].name[0] = 0;
+      var_disp_list[i].type = 0;
+      var_disp_list[i].index = 0;
+      var_disp_list[i].val.fa = NULL;
+   }
+}
+
+#define prt_spaces(n)                                                                                                            \
+   for (int j = 0; j < n; j++)                                                                                                   \
+      MMputchar(' ', 0);
+#define duplicate_chars(c, n)                                                                                                    \
+   for (int j = 0; j < n; j++)                                                                                                   \
+      MMputchar(c, 0);
+
+void Debugger_Open_Edit_Box() {
+   int i;
+
+   VT100_forground_white();
+   VT100_background_black();
+   VT100_goto_xy(DBG_X_COLUMN + 8, 13);
+   prt_spaces(72);
+
+   VT100_goto_xy(DBG_X_COLUMN + 9, 14);
+   MMPrintString(" ------Enter Print of Variable or Assign New Value to a Variable----- ");
+   for (i = 0; i < 6; i++) {
+      VT100_goto_xy(DBG_X_COLUMN + 9, 15 + i);
+      MMputchar(' ', 0);
+      MMputchar('|', 0);
+      prt_spaces(66);
+      MMputchar('|', 0);
+      MMputchar(' ', 0);
+   }
+   VT100_goto_xy(DBG_X_COLUMN + 9, 21);
+   MMputchar(' ', 0);
+   duplicate_chars('-', 68);
+   MMputchar(' ', 0);
+   VT100_goto_xy(DBG_X_COLUMN + 8, 22);
+   prt_spaces(72);
+}
+
+void Debugger_set_screen_up_for_return() {
+   VT100_forground_white();
+   VT100_background_black();
+   VT100_restore_cursor();
+}
+

--- a/PicoMite/Debugger.c
+++ b/PicoMite/Debugger.c
@@ -1,0 +1,947 @@
+/***********************************************************************************************************************
+PicoMite MMBasic
+
+Debugger.c
+
+<COPYRIGHT HOLDERS>  E. David Neufeld
+Copyright (c) 2023, <COPYRIGHT HOLDERS> All rights reserved.
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following
+conditions are met: 1.	Redistributions of source code must retain the above copyright notice, this list of conditions and the
+following disclaimer.
+2.	Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+disclaimer in the documentation and/or other materials provided with the distribution.
+3.	The name MMBasic be used when referring to the interpreter in any documentation and promotional material and the original
+copyright message be displayed on the console at startup (additional copyright messages may be added). 4.	All advertising
+materials mentioning features or use of this software must display the following acknowledgement: This product includes software
+developed by the <copyright holder>. 5.	Neither the name of the <copyright holder> nor the names of its contributors may be used
+to endorse or promote products derived from this software without specific prior written permission. THIS SOFTWARE IS PROVIDED BY
+<COPYRIGHT HOLDERS> AS IS AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDERS> BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+************************************************************************************************************************/
+
+#define INCLUDE_FUNCTION_DEFINES
+
+#include "MMBasic_Includes.h"
+//#include "AllCommands.h"
+#include "Debugger.h"
+#include "Hardware_Includes.h"
+#include "class/cdc/cdc_device.h"
+
+#ifdef PICOMITEVGA
+#endif
+
+#ifdef PICOMITE
+#endif
+
+#ifdef PICOMITEWEB
+#endif
+
+//
+// It is expected that the user will be using the MicroMite Control Centre and have a mouse attached to the system.   The Debugger
+// will work with just a keyboard, but functionality and power of the Debugger will be reduced in this configuration.  The
+// terminal screen of MicroMite Control Centre needs to be expanded from what it normally defaults to.   The reason is the
+// Debugger needs screen space to display its information while at the same time preserving much of the screen that the BASIC
+// program being debugged needs to provide input and output.
+//
+// The user needs to do issue commands within MMBASIC at the prompt to set the display options:
+//			> OPTION ESCAPE ON
+// 			> Option Display 45,145
+//                      > Option Colourcode On
+//
+// The user also needs to install a recent version of the MicroMite Control Panel.   (The Debugger needs Cursor Save/Restore
+// capability and that feature was not enabled on older versions of the MMCC.)
+//
+// After bringing up the Debugger and using it, the user may find that the calibration of the mouse cursor is not very accurate.
+// The user may need to adjust the Click Y shift=? and Click X shift=?  In MMCC.inf.   MMCC.inf is located in
+// C:\Users\EDN\AppData\Local\MMedit5  on my system.  On my Windows system I needed to make Click Y shift=15 for reasonable
+// accuracy.
+//
+//
+
+int n_disp_elements = 0;
+int dbg_n_scrn_lines = 0;
+struct var_disp_element var_disp_list[DISPLAY_LIST_SIZE] = {{"", T_NOTYPE, 0.0}};
+struct dbg_screen_info dbg_scrn_lines[N_DBG_CODE_LINES] = {{NULL, -1}};
+int top_scrn_line_cnt = -1;
+
+int Rem_cmd = -1, Return_cmd = -1, GoTo_cmd = -1, On_cmd = -1;
+
+extern jmp_buf mark;
+jmp_buf dbg_cmd_prompt, tmp_jmp_buf;
+
+int debugger_scrn_x_column = DBG_X_COLUMN;
+int debugger_scrn_y_size = DBG_Y_ROW;
+int Mouse_X, Mouse_Y;
+
+unsigned char *MMDebug_Brk_Pnt_Addr = NULL;
+
+void printLine(int);
+void SetColour(unsigned char *, int);
+char *findLine(int);
+
+unsigned char *b_pnt; // These two variables are very important.  This is a pointer to the code location where the break point
+                      // triggered. and the BASIC interpreter suspends itself and gives up control to the Debugger
+int b_pnt_line_count; // This it how many lines into the BASIC program the break point trigger happened
+
+unsigned char *Debugger(unsigned char *p) {
+   unsigned char *ptr, *pp;
+   char str[20];
+   static int terminal_at_correct_size = 0;
+   int i, c;
+
+   MMDebug_Brk_Pnt_Addr = NULL; // and clear any Break Points.   These will get set appropriately with
+   MMDebug_Level_Change = -1;   // a Step or Go command
+   MMDebug = 0;
+
+   if (!terminal_at_correct_size++)
+      setup_terminal_screen_to_145x45();
+
+   if (Rem_cmd == -1)
+      Debugger_find_special_cmds();
+
+   b_pnt = p;
+   b_pnt_line_count = Debug_CountLines(p);
+
+   if (!Option.ColourCode || Option.Height != 45 ||
+       Option.Width != 145) {   // If the user doesn't have options set up correctly, we fix
+      Option.ColourCode = true; // that problem here.   But the user will need to re-enter
+      Option.Height = 45;       // the Debugger to have things correct.
+      Option.Width = 145;
+      SaveOptions();
+      setup_terminal_screen_to_145x45();
+      MMPrintString("\r\n\r\nOptions were not set correctly.\r\nThat is fixed now.\r\n");
+      //		return p;
+   }
+
+   VT100_save_cursor();
+   VT100_Mouse_Mode_On();
+   VT100_Clear_Debugger_Screen();
+
+   VT100_goto_xy(debugger_scrn_x_column + 1, debugger_scrn_y_size + 1);
+   VT100_forground_white();
+   VT100_background_black();
+
+   //--------------------------------------------
+
+   if (top_scrn_line_cnt < 0)
+      top_scrn_line_cnt = b_pnt_line_count - 5;
+
+   if (b_pnt_line_count > top_scrn_line_cnt + 20)
+      top_scrn_line_cnt = b_pnt_line_count - 5;
+
+   if (b_pnt_line_count < top_scrn_line_cnt)
+      top_scrn_line_cnt = b_pnt_line_count - 5;
+
+   if (top_scrn_line_cnt < 1)
+      top_scrn_line_cnt = 1;
+
+   VT100_forground_white();
+   VT100_background_black();
+
+   if (b_pnt_line_count > 1)
+      Debugger_find_variables_used_by_line(b_pnt_line_count - 1);
+   Debugger_find_variables_used_by_line(b_pnt_line_count); // <----<<<   may need to be deleted
+
+   Debugger_highlight_line(b_pnt_line_count);
+
+   while (1) {
+
+      if (!Debugger_input_pending()) {
+         Debugger_Paint_Code_Lines(top_scrn_line_cnt);
+         Debugger_var_display();
+         Debugger_Prompt();
+         Debugger_Status_Info();
+      }
+
+      c = Debugger_getc();
+      c = toupper(c);
+
+      switch (c) {
+
+      case -1:     // if the person is using TeraTerm, a Mouse Click down and a Mouse Click up gets reported.  
+	 break;    // Debugger_getc() eats the Mouse Click up and returns -1.   This is the final action to eat 
+                   // the extra mouse click.    
+      case '.':    
+         break;
+
+      case '?':
+         break;
+
+      case MOUSE_CLICK:
+         VT100_goto_xy(100, debugger_scrn_y_size); // Report Mouse Click location
+         VT100_forground_red();
+         VT100_background_yellow();  // it may make sense to leave this coordinate display for a short while
+         MMPrintString(" (");        // because users may need to adjust the cursor offsets on their
+         IntToStr(str, Mouse_X, 10); // MMCC displays
+         MMPrintString(str);
+         MMPrintString(","); // But if not....   this code can be safely deleted
+         IntToStr(str, Mouse_Y, 10);
+         MMPrintString(str);
+         MMPrintString(") ");
+         VT100_background_black();
+         VT100_forground_white();
+
+         if (Mouse_Y < 1 || Mouse_Y > debugger_scrn_y_size - 3 || Mouse_X < debugger_scrn_x_column || Mouse_X > 145) {
+            Debugger_display_error_message(" ??? Poorly Placed Mouse Click. ");
+            break;
+         }
+
+         Debugger_find_variables_used_by_line(top_scrn_line_cnt + Mouse_Y - 1);
+         Debugger_highlight_line(top_scrn_line_cnt + Mouse_Y - 1);
+         Debugger_Pause(250);
+
+         VT100_goto_xy(debugger_scrn_x_column + 1, 1);
+         break;
+
+      case HOME:
+         top_scrn_line_cnt = 1;
+         break;
+
+      case END:
+         top_scrn_line_cnt = Debug_CountLines((unsigned char *)0x20000000) - debugger_scrn_y_size - 5; 
+         break;
+
+      case PUP:
+         top_scrn_line_cnt -= (debugger_scrn_y_size * 4) / 5;
+         if (top_scrn_line_cnt < 1)
+            top_scrn_line_cnt = 1;
+         break;
+
+      case PDOWN:
+         top_scrn_line_cnt += (debugger_scrn_y_size * 4) / 5;
+         if (top_scrn_line_cnt > Debug_CountLines((unsigned char *)0x20000000) - debugger_scrn_y_size)
+            top_scrn_line_cnt = Debug_CountLines((unsigned char *)0x20000000) - debugger_scrn_y_size + 5;
+         break;
+
+      case UP:
+         top_scrn_line_cnt--;
+         if (top_scrn_line_cnt < 1)
+            top_scrn_line_cnt = 1;
+         continue;
+
+      case DOWN:
+         top_scrn_line_cnt++;
+         if (top_scrn_line_cnt > Debug_CountLines((unsigned char *)0x20000000) - debugger_scrn_y_size)
+            top_scrn_line_cnt = Debug_CountLines((unsigned char *)0x20000000) - debugger_scrn_y_size + 5;
+         continue;
+
+      case 's':
+      case 'S':
+      case STEP:
+         Debugger_set_screen_up_for_return();
+         MMDebug = true;              // STEP is the easiest.   We just leave the MMDebug flag enabled
+         MMDebug_Brk_Pnt_Addr = NULL; // and clear any Break Points.  The main interpreter loop will stop
+         return p;                    // after the next command is executed.
+         break;
+
+      case STEP_OUT:
+         if (gosubindex == 0) {
+            VT100_goto_xy(80, debugger_scrn_y_size);
+            VT100_forground_red();
+            VT100_background_yellow();
+            MMPrintString(" --Nothing to Step Out of--");
+            VT100_background_black();
+            VT100_forground_white();
+            break;
+         }
+
+         MMDebug = false; // STEP-OUT is fairly easy.
+
+         if (gosubstack[gosubindex - 1] == NULL) { // This is a user defined function.  Tell the
+            MMDebug_Brk_Pnt_Addr = NULL;           // interpreter to stop when it sees the lower level
+            MMDebug_Level_Change = gosubindex - 1;
+         } else {                                              // Otherwise it is a subroutine
+            MMDebug_Brk_Pnt_Addr = gosubstack[gosubindex - 1]; // We load the Break Pnt address with the top of
+            while (*MMDebug_Brk_Pnt_Addr == 0)                 // the Return stack.
+               MMDebug_Brk_Pnt_Addr++;                         // and bump past the EOL if necessary
+         }
+
+         Debugger_set_screen_up_for_return();
+         return p;
+         break;
+      case 'o':
+      case 'O':
+      case STEP_OVER:
+         VT100_forground_red();     // STEP_OVER can step over Gosub's, For/Next loops, Do loops and expressions
+         VT100_background_yellow(); // that get evaluated using multiple line user defined functions.   It can
+         pp = p;                    // also step over multiple commands on a single line.
+         pp = GetNextCommand(pp, NULL, (unsigned char *)"Unable to Step-Over");
+
+         if (*pp == GoTo_cmd || *pp == On_cmd || *pp == cmdIF) { // Check for simple commands that change the program flow
+            Debugger_set_screen_up_for_return();
+            MMDebug_Brk_Pnt_Addr = NULL; // We will just set the MMDebug flag to stop execution instead
+            MMDebug = true;              // of trying to figure out where the Break Points should be
+            return b_pnt;
+         }
+
+         if (*pp == cmdSELECT_CASE) {
+            i = 1;
+            while (1) {
+               pp = GetNextCommand(pp, NULL, (unsigned char *)"No matching END SELECT");
+               if (*pp == cmdSELECT_CASE)
+                  i++; // entered a nested Select Case
+               if (*pp == cmdEND_SELECT)
+                  i--; // exited a nested Select Case
+
+               if (i == 0)
+                  break; // found our matching End Select
+            }
+            skipelement(pp);
+            pp++;
+            Debugger_set_screen_up_for_return();
+            MMDebug_Brk_Pnt_Addr = pp;
+            MMDebug = false;
+            return b_pnt;
+         } else
+
+             if (*pp == cmdFOR) {
+            i = 1;
+            while (1) {
+               pp = GetNextCommand(pp, NULL, (unsigned char *)"No matching NEXT");
+               if (*pp == cmdFOR)
+                  i++; // entered a nested For/Next loop
+               if (*pp == cmdNEXT)
+                  i--; // exited a nested For/Next loop
+
+               if (i == 0)
+                  break; // found our matching NEXT
+            }
+            skipelement(pp);
+            pp++;
+            Debugger_set_screen_up_for_return();
+            MMDebug_Brk_Pnt_Addr = pp;
+            MMDebug = false;
+            return b_pnt;
+         } else
+
+             if (*pp == cmdDO) {
+            i = 1;
+            while (1) {
+               pp = GetNextCommand(pp, NULL, (unsigned char *)"No matching LOOP");
+               if (*pp == cmdDO)
+                  i++; // entered a nested DO or WHILE loop
+               if (*pp == cmdLOOP)
+                  i--; // exited a nested loop
+
+               if (i == 0)
+                  break; // found our matching LOOP or WEND stmt
+            }
+            skipelement(pp);
+            pp++;
+            Debugger_set_screen_up_for_return();
+            MMDebug_Brk_Pnt_Addr = pp;
+            MMDebug = false;
+            return b_pnt;
+         }
+
+         /*
+          *
+          *  If we get to this point, we aren't handling a For/Next or a Do/Loop or a subroutine.   The user just wants to step
+          * over a line that will get bogged down in lots of noisy BASIC statements like user defined function being evaluated.
+          *
+          */
+
+         VT100_goto_xy(DBG_X_COLUMN + 1, b_pnt_line_count - top_scrn_line_cnt + 2); // +2 because we highlight the
+         VT100_forground_red();                                                     // next line, not the current line
+         VT100_background_yellow();
+         IntToStr(str, b_pnt_line_count + 1, 10);
+         MMPrintString(str);
+         MMPrintString(":");
+
+         ptr = LocateProgramStatement(b_pnt_line_count + 1);
+         Debugger_Pause(150);
+
+         Debugger_set_screen_up_for_return();
+         MMDebug_Brk_Pnt_Addr = ptr;
+         MMDebug = false;
+
+         return b_pnt;
+
+      case BRK_PNT_and_GO:
+         ptr = LocateProgramStatement(top_scrn_line_cnt + Mouse_Y - 1);
+         VT100_goto_xy(DBG_X_COLUMN + 1, Mouse_Y);
+         VT100_forground_red();
+         VT100_background_yellow();
+         IntToStr(str, top_scrn_line_cnt + Mouse_Y - 1, 10);
+         MMPrintString(str);
+         MMPrintString(":");
+         Debugger_Pause(100);
+
+         Debugger_set_screen_up_for_return();
+         MMDebug_Brk_Pnt_Addr = ptr;
+         MMDebug = false;
+
+         return b_pnt;
+
+      case GO:
+         Debugger_set_screen_up_for_return();
+         MMDebug_Brk_Pnt_Addr = NULL;
+         MMDebug = false;
+
+         return b_pnt;
+
+      case EDIT_VALUE: {
+         int reason;
+         jmp_buf /* dbg_edit_box,*/ tmp_jmp_buf;
+
+         memcpy(tmp_jmp_buf, mark, sizeof(jmp_buf)); // For sure the user is going to have syntax errors
+                                                     // that cause the interpretor to have convolusions.
+                                                     // When that happens, we want control to come back to
+                                                     // the debug session and not end up at a command prompt
+
+         while (1) {
+            unsigned char *ttp = NULL, *ucp;
+
+            Debugger_Open_Edit_Box();
+
+            reason = setjmp(mark);
+            if (reason) {
+               VT100_goto_xy(DBG_X_COLUMN + 14, 21);
+               VT100_forground_red();
+               VT100_background_yellow();
+               MMPrintString("---Syntax Error---");
+            }
+
+            VT100_goto_xy(DBG_X_COLUMN + 12, 15);
+            VT100_forground_cyan();
+            VT100_background_black();
+            MMPrintString(" > ");
+
+            Debugger_getline((char *)inpbuf);
+            if (strlen((char *)inpbuf) < 1)
+               break;
+
+            if (inpbuf[0] >= DBG_BUTTON_STEP && inpbuf[0] <= DBG_BUTTON_PAGE_DOWN) {
+               VT100_goto_xy(80, debugger_scrn_y_size);
+               VT100_forground_cyan();
+               VT100_background_yellow();
+               MMPrintString(" (");
+               IntToStr(str, Mouse_X, 10);
+               MMPrintString(str);
+               MMPrintString(",");
+               IntToStr(str, Mouse_Y, 10);
+               MMPrintString(str);
+               MMPrintString(") ");
+               VT100_background_black();
+               VT100_forground_white();
+            }
+            ucp = inpbuf;
+            skipspace(ucp);
+
+            multi = false;
+            tokenise(true); // and tokenise it (the result is in tknbuf)
+            memset(ucp, 0, STRINGSIZE);
+            tknbuf[strlen((char *)tknbuf)] = 0;
+            tknbuf[strlen((char *)tknbuf) + 1] = 0;
+            ttp = nextstmt; // save the globals used by commands
+
+            VT100_goto_xy(DBG_X_COLUMN + 12, 17);
+            ScrewUpTimer = 1000;
+            ExecuteProgram(tknbuf); // actually do the work
+            ScrewUpTimer = 0;
+
+            TempMemoryIsChanged = true; // signal that temporary memory should be checked
+            nextstmt = ttp;
+
+            Debugger_var_display();
+
+            while (Debugger_input_pending()) // eat any extra characters
+               Debugger_get_char();
+
+            while (!Debugger_input_pending()) // now wait for the user to view the results
+               ;
+         }
+
+         Debugger_get_char();
+         memcpy(mark, tmp_jmp_buf, sizeof(jmp_buf)); // Restore MMBasic's abort longjmp()
+         VT100_forground_white();
+         VT100_background_black();
+         break;
+      }
+      case 'q':
+      case 'Q':
+      case QUIT:
+         Debugger_set_screen_up_for_return();
+         MMDebug_Brk_Pnt_Addr = NULL; // Disable all Break Pnt's
+         MMDebug = false;
+         cmd_end();
+         break;
+
+      default:
+         Debugger_display_error_message(" ??? Invalid debugger command. ");
+         break;
+      }
+   }
+
+   VT100_restore_cursor();
+   MMDebug = false;
+
+   return p;
+}
+
+void Debugger_Pause(int ms) {
+   InkeyTimer = 0; // BASIC is suspended, so we can grab the
+                   // InkeyTimer instead of creating our own timer
+   while (InkeyTimer < ms)
+      ; // a brief pause to let the user see the message
+}
+
+void Debugger_display_error_message(char *err) {
+   int l, i;
+
+   l = strlen(err);
+   VT100_goto_xy(debugger_scrn_x_column + 1, debugger_scrn_y_size);
+   VT100_forground_red();
+   VT100_background_yellow();
+   MMPrintString(err);
+
+   Debugger_Pause(500);
+
+   VT100_forground_white(); // restore the screen
+   VT100_goto_xy(debugger_scrn_x_column + 1, debugger_scrn_y_size);
+   VT100_forground_cyan();
+   VT100_background_black();
+   for (i = 0; i < l; i++)
+      MMPrintString("_");
+   VT100_forground_white();
+}
+
+void Debugger_highlight_line(int ln) {
+   int row;
+   unsigned char str[MAXSTRLEN];
+   unsigned char *ptr;
+
+   ptr = LocateProgramStatement(ln); // blink the selected line
+   row = ln - top_scrn_line_cnt + 1;
+
+   if (row < 1) {
+      VT100_goto_xy(80, debugger_scrn_y_size);               // this can be removed later, after debug
+      VT100_forground_red();                                 // this can be removed later, after debug
+      VT100_background_yellow();                             // this can be removed later, after debug
+      MMPrintString(" --Can't highlight off screen line--"); // this can be removed later, after debug
+      VT100_background_black();                              // this can be removed later, after debug
+      VT100_forground_white();                               // this can be removed later, after debug
+      return;
+   }
+
+   VT100_goto_xy(debugger_scrn_x_column + 1, row);
+   IntToStr((char *)str, ln, 10);
+
+   VT100_forground_yellow();
+
+   MMPrintString((char *)str);
+   MMPrintString(":");
+   if (ln < 100)
+      MMPrintString("  ");
+   else if (ln < 10)
+      MMPrintString(" ");
+
+   VT100_goto_xy(debugger_scrn_x_column + 5, row);
+   llist(str, ptr);
+   MMPrintString((char *)str);
+   VT100_forground_white();
+}
+
+void add_variable_to_display_list(unsigned char *str) {
+   int i, j, l, vi;
+   struct var_disp_element tmp;
+   void *ptr;
+
+   l = strlen((char *)str);
+   for (i = 0; i < l; i++)
+      str[i] = toupper(str[i]);
+
+   // don't add something that is not currently defined as a variable
+
+   if (str[l] == '!')
+      ptr = findvar(str, V_NOFIND_NULL | T_IMPLIED | T_NBR);
+   else if (str[l] == '$')
+      ptr = findvar(str, V_NOFIND_NULL | T_IMPLIED | T_STR);
+   else if (str[l] == '%')
+      ptr = findvar(str, V_NOFIND_NULL | T_IMPLIED | T_INT);
+   else
+      ptr = findvar(str, V_NOFIND_NULL);
+
+   vi = VarIndex; // remember where it was found (assumming it was found)
+   if (ptr == NULL)
+      return;
+
+   for (i = 0; i < n_disp_elements; i++) { // check if the specified variable is already in our display list
+      if (strcmp((char *)var_disp_list[i].name, (char *)str) == 0) {
+         tmp = var_disp_list[i];
+         for (j = i; j > 0; j--)
+            var_disp_list[j] = var_disp_list[j - 1]; // slide the list down to where we found the variable
+         var_disp_list[0] = tmp;                     // and put the specified variable at the top of the list
+         return;
+      }
+   }
+
+   for (j = DISPLAY_LIST_SIZE - 1; j > 0; j--)
+      var_disp_list[j] = var_disp_list[j - 1]; // slide the list down to where we found the variable
+   n_disp_elements++;
+   if (n_disp_elements > DISPLAY_LIST_SIZE)
+      n_disp_elements = DISPLAY_LIST_SIZE;
+
+   strcpy((char *)var_disp_list[0].name, (char *)str);
+
+   var_disp_list[0].type = vartbl[vi].type;
+   var_disp_list[0].index = vi;
+   switch (vartbl[vi].type) {
+   case T_NBR:
+      var_disp_list[0].val.f = (MMFLOAT)0.0;
+      break;
+   case T_INT:
+      var_disp_list[0].val.i = (long long int)0;
+      break;
+   case T_STR:
+      var_disp_list[0].val.s = vartbl[vi].val.s;
+      break;
+   case T_NOTYPE:
+      var_disp_list[0].val.s = (void *)NULL;
+      break;
+   default:
+      var_disp_list[0].val.s = (void *)NULL;
+      break;
+   }
+}
+
+int is_at_start_of_line(unsigned char *p) {
+   unsigned char *p2;
+   int ln;
+
+   ln = Debug_CountLines(p);
+   p2 = LocateProgramStatement(ln);
+
+   if (p == p2)
+      return 1;
+   else
+      return 0;
+}
+
+void Debugger_Paint_Code_Lines(int start_line) {
+   int j, k = 0, l, l2;
+   unsigned char *pp; //, *ptr;
+   unsigned char str[STRINGSIZE];
+
+   for (j = top_scrn_line_cnt; j < top_scrn_line_cnt + N_DBG_CODE_LINES; j++) {
+
+      if (Debugger_input_pending())
+         return;
+
+      VT100_goto_xy(debugger_scrn_x_column + 1, j - top_scrn_line_cnt + 1);
+
+      VT100_all_attr_off();
+
+      if (b_pnt_line_count == j) {
+         VT100_background_yellow();
+         VT100_forground_red();
+      }
+
+      IntToStr((char *)str, j, 10);
+      MMPrintString((char *)str);
+      MMPrintString(":");
+      if (j < 100)
+         MMPrintString("  ");
+      else if (j < 10)
+         MMPrintString(" ");
+
+      pp = LocateProgramStatement(j);
+      VT100_background_black();
+      VT100_Clear_to_EOL();
+
+      if (pp == NULL) // end of the program
+         break;
+
+      llist(str, b_pnt);
+      l2 = strlen((char *)str);
+
+      llist(str, pp);
+      l = strlen((char *)str);
+
+      VT100_goto_xy(debugger_scrn_x_column + 5, j - top_scrn_line_cnt + 1);
+      SetColour(NULL, true);
+
+      if (b_pnt_line_count == j) {
+         k = 0;
+         if (l2 < l) { // if true, we are in the middle part of the line.
+            for (k = 0; k < (l - l2); k++) {
+               SetColour((unsigned char *)&str[k], true);
+               MMputchar(str[k], 0);
+            }
+         }
+
+         VT100_background_yellow();
+         VT100_forground_red();
+         for (; k < l; k++) {
+            if (str[k] == ':')    // Using a ':' to terminate the active statement element fails if we have a quoted string
+               break;             // with a colon in it.  Only part of the element will be high lighted.   But this saves us
+            MMputchar(str[k], 0); // a lot of stack space because we don't need a 2nd string to llist() into looking for
+         }                        // the true end of the element.   The user still gets enough of the element highlighted
+                                  // to know where the next execution of logic is happening.
+         VT100_forground_white();
+         VT100_background_black();
+         SetColour(NULL, true);
+         for (; k < l; k++) {
+            if (k >= l)
+               break;
+            SetColour((unsigned char *)&str[k], true);
+            MMputchar(str[k], 0);
+         }
+
+         VT100_forground_white();
+         VT100_background_black();
+         VT100_Clear_to_EOL();
+      } else {
+         for (k = 0; k < 145 - debugger_scrn_x_column - 7; k++) { // Simple loop to display the line if this isn't
+            if (k >= l)                                           // the screen row we are Break Pointed on.
+               break;
+            SetColour((unsigned char *)&str[k], true);
+            MMputchar(str[k], 0);
+         }
+         SetColour(NULL, true);
+      }
+   }
+}
+
+void dump_current_program_info(unsigned char *p, int row) {
+   /*
+           char str[250];
+           unsigned char *pp;
+           int i;
+
+           pp = p;
+
+           VT100_goto_xy( 1, row );
+           VT100_forground_white();
+           VT100_background_black();
+           Debug_Info_hex(" ProgMemory: 0x", (int) ProgMemory);
+           Debug_Info_hex(" Entry: 0x", (int) p);
+           Debug_Info("  Line:", b_pnt_line_count);
+           Debug_Info(" LastLine:",  Debug_CountLines( (unsigned char *) 0x20000000 ) );
+           Debug_Info_hex(" End: 0x", (int)  LocateProgramStatement(Debug_CountLines( (unsigned char *) 0x20000000 ) )  );
+           Debug_Info_hex(" b_pnt: 0x", (int) b_pnt );
+           Debug_Info(" gosubindex:",  gosubindex);
+           Debug_Info_hex(" gosub stk: 0x", (int) gosubstack[gosubindex - 1] );
+
+
+           VT100_goto_xy( 1, row+1 );
+           llist((unsigned char *) str, pp);
+           MMPrintString(str);
+           MMPrintString("                                                           ");
+
+           VT100_goto_xy( 1, row+2 );
+           for(i=-4; i<43; i++ ) {
+               if (i==0)
+                       MMPrintString("|");
+               IntToStr(str, (int) pp[i], 16);
+               while (strlen(str)<3)
+                  strcat(str," ");
+               MMPrintString(str);
+           }
+
+           VT100_goto_xy( 1, row+3 );
+           for(i=-4; i<43; i++ ) {
+               if (i==0)
+                       MMPrintString("|");
+               MMPrintString(" ");
+               if ( pp[i] > 31 && pp[i]<127 )
+                       MMputchar(pp[i],1);
+               else
+                       MMputchar('.',1);
+               MMPrintString(" ");
+           }
+   */
+}
+
+void dump_mem(unsigned char *p, int row) {
+   /*
+           char str[250];
+           unsigned char *pp;
+           int i;
+
+           pp = p;
+
+           VT100_goto_xy( 1, row );
+           VT100_forground_white();
+           VT100_background_black();
+
+
+           VT100_goto_xy( 1, row+1 );
+           llist((unsigned char *) str, pp);
+           MMPrintString(str);
+           MMPrintString("                                                           ");
+
+           VT100_goto_xy( 1, row+2 );
+           for(i=-4; i<38; i++ ) {
+               if (i==0)
+                       MMPrintString("|");
+               IntToStr(str, (int) pp[i], 16);
+               while (strlen(str)<3)
+                  strcat(str," ");
+               MMPrintString(str);
+           }
+
+           VT100_goto_xy( 1, row+3 );
+           for(i=-4; i<38; i++ ) {
+               if (i==0)
+                       MMPrintString("|");
+               MMPrintString(" ");
+               if ( pp[i] > 31 && pp[i]<127 )
+                       MMputchar(pp[i],1);
+               else
+                       MMputchar('.',1);
+               MMPrintString(" ");
+           }
+   */
+}
+
+void Debugger_find_variables_used_by_line(int ln) {
+   unsigned char var_name[MAXVARLEN + 1];
+   unsigned char str[MAXSTRLEN];
+   unsigned char *ptr, *p, *wp, *ps;
+   int i, j, l = -1, row;
+
+   ptr = LocateProgramStatement(ln); // blink the selected line
+   row = ln - top_scrn_line_cnt + 1;
+
+   if (row < 1)
+      return;
+
+   VT100_goto_xy(debugger_scrn_x_column + 1, row);
+   IntToStr((char *)str, ln, 10);
+
+   VT100_forground_yellow();
+
+   MMPrintString((char *)str);
+   MMPrintString(":");
+   VT100_goto_xy(debugger_scrn_x_column + 5, row);
+
+   if (*ptr == 0xff || (ptr[0] == 0 && ptr[1] == 0)) // end of the program
+      return;
+
+   if (*ptr == T_NEWLINE)
+      ptr++; // and step over the new line marker
+
+   if (*ptr == T_LINENBR)
+      ptr += 3; // and step over the line number
+
+   if (*ptr == T_LABEL)
+      ptr += ptr[0] + 2; // still looking! skip over the label
+
+   p = llist(str, ptr); // p points to the next line.   The line we are dealing with is
+                        // between ptr and p
+
+   for (i = 0; i < p - ptr; i++) // get a copy of the tokenized line.   We will parse through this
+      str[i] = ptr[i];           // copy to find variable names.   We get more than we need just to make
+                                 // sure we have the complete line to parse.
+
+   p = wp = str;
+   while (1) {
+      if (*p == 0x01)
+         break; // End of Line
+      if (*p == 0x00 && *(p + 1) == 0x00)
+         break; // End of Program
+      *wp++ = *p++;
+      while (*(p - 1) == ' ' && *p == ' ')
+         p++;
+   }
+
+   *wp = 0;
+   *(wp + 1) = 0x01; // add a new line command just so we know it is there to make searches easier
+   l = wp - str;
+   p = str;
+
+   // p now points at the start of logic on the line
+
+   ps = p;     // save the start of the logic on the line
+   while (1) { // now we need to know where the end of the line is
+      if (*p == 0x01)
+         break; // End of Line
+      if (*p == 0x00 && *(p + 1) == 0x00)
+         break; // End of Program
+      p++;
+   }
+   p--; // p now points at the end of the line  (the last character of the line)
+
+   l = p - ps; // l holds the length of the logic
+
+   for (i = 0; i < l; i++) { // first we kill any literal text so we don't get confused and think there is a variable name there
+      if (ps[i] == '\"') {
+         ps[i] = 0xff;
+         for (j = i + 1; j < l; j++) {
+            if (ps[j] == '\"') {
+               ps[j] = 0xff; // found the trailing quote.  kill it
+               i = j;        // and jump i ahead to continue the scan across the line's logic
+               break;
+            }
+            ps[j] = 0xff; // still inside the quoted text.  kill it
+         }
+      }
+   }
+
+   for (i = 0; i < l; i++) // now kill any comments at the end of the line
+      if (ps[i] == '\'') {
+         ps[i] = 0x00; // mark the new end of line
+         for (j = i + 1; j < l; j++)
+            ps[j] = 0xff;
+         l = i; // shorten the length
+         break;
+      }
+
+   for (i = 0; i < l; i++) { // check if this is a Rem command.  If so, there are no variables.  We bug out.
+      if (ps[i] == Rem_cmd)
+         return;
+   }
+
+   for (i = 0; i < l; i++) {
+      if (ps[i] >= C_BASETOKEN) // kill any commands
+         ps[i] = 0xff;
+      if (ps[i] == ' ') // kill any spaces
+         ps[i] = 0xff;
+   }
+
+   //--------- Ready to scan across the line and pick out the variables in it ---------------
+   for (i = 0; i < l; i++) {
+      if (isnamestart(ps[i])) {
+         p = &ps[i];
+         wp = var_name;
+
+         *wp++ = *p++;
+         *wp = 0;
+
+         while (isnamechar(*p) && MAXVARLEN > (wp - var_name)) {
+            *wp++ = *p++;
+            *wp = 0;
+         }
+
+         if (isnameend(*p)) {
+            *wp++ = *p++;
+            *wp = 0;
+         }
+
+         while (*p == ' ')
+            p++;
+         i += p - &ps[i];
+         if (*p != '(')
+            add_variable_to_display_list(var_name);
+      }
+   }
+}
+
+void Debugger_Status_Info() {
+   char str[10];
+   if (gosubindex != 0) {
+      VT100_goto_xy(145 - 9, debugger_scrn_y_size);
+      VT100_forground_red();
+      VT100_background_yellow();
+      MMPrintString("Level:");
+      IntToStr(str, gosubindex, 6);
+      MMPrintString(str);
+   }
+}
+

--- a/PicoMite/Debugger.h
+++ b/PicoMite/Debugger.h
@@ -1,0 +1,196 @@
+/***********************************************************************************************************************
+PicoMite MMBasic
+
+Debugger.h
+
+<COPYRIGHT HOLDERS>  E. David Neufeld
+Copyright (c) 2023, <COPYRIGHT HOLDERS> All rights reserved. 
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: 
+1.	Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+2.	Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer
+        in the documentation and/or other materials provided with the distribution.
+3.	The name MMBasic be used when referring to the interpreter in any documentation and promotional material and the original
+        copyright message be displayed on the console at startup (additional copyright messages may be added).
+4.	All advertising materials mentioning features or use of this software must display the following acknowledgement: This product includes 
+        software developed by the <copyright holder>.
+5.	Neither the name of the <copyright holder> nor the names of its contributors may be used to endorse or promote products derived from this 
+        software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY <COPYRIGHT HOLDERS> AS IS AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDERS> BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+
+************************************************************************************************************************/
+
+
+/**********************************************************************************
+ the C language function associated with commands, functions or operators should be
+ declared here
+**********************************************************************************/
+#if !defined(INCLUDE_COMMAND_TABLE) && !defined(INCLUDE_TOKEN_TABLE)
+
+#define DBG_X_COLUMN		40
+#define DBG_Y_ROW		30
+#define DBG_VAR_COLUMN		(DBG_X_COLUMN+83)
+#define DBG_VAR_VAL_COLUMN	(DBG_X_COLUMN+98)
+
+/*
+#define STEP		132
+#define STEP_OUT	133
+#define STEP_OVER	0x91
+#define BRK_PNT_and_GO  0x92
+#define GO		0x93
+#define EDIT_VALUE 	0x94
+#define QUIT	 	0x95
+*/
+#define STEP		0x8d
+#define STEP_OUT	0x8e
+#define STEP_OVER	0x8f
+#define BRK_PNT_and_GO  0x90
+#define GO		0x91
+#define EDIT_VALUE 	0x92
+#define QUIT	 	0x93
+
+
+#define DISPLAY_LIST_SIZE	20
+#define N_DBG_CODE_LINES	25 
+#define N_DEBUG_UNGETCHAR	5
+
+#define DBG_BUTTON_STEP			1
+#define DBG_BUTTON_STEP_OVER		8
+#define DBG_BUTTON_STEP_OUT		15
+#define DBG_BUTTON_GO			22
+#define DBG_BUTTON_EDIT_VALUE		40
+#define DBG_BUTTON_QUIT			82
+#define DBG_BUTTON_LINE_UP		93
+#define DBG_BUTTON_LINE_DOWN		93
+#define DBG_BUTTON_PAGE_UP		100
+#define DBG_BUTTON_PAGE_DOWN		100
+
+
+struct var_disp_element {
+	unsigned char name[MAXVARLEN+1];
+	unsigned char type;
+	int           index;
+	union u_val   val; };
+
+extern int n_disp_elements;
+extern struct var_disp_element var_disp_list[DISPLAY_LIST_SIZE];
+
+struct dbg_screen_info {
+	unsigned char *code;
+	int            line_nbr;
+};
+
+extern int debugger_scrn_x_column, debugger_scrn_y_size;
+extern int dbg_n_scrn_lines; 
+extern struct dbg_screen_info dbg_scrn_lines[N_DBG_CODE_LINES]; 
+extern int  Rem_cmd, Return_cmd, GoTo_cmd, On_cmd;
+
+extern jmp_buf dbg_edit_box, tmp_jmp_buf;
+
+unsigned char *Debugger(unsigned char *);
+void ClearDebugger();
+void Debugger_Prompt();
+void Debugger_set_screen_up_for_return();
+int  Debugger_getc();
+void Debugger_unget_char(int );
+int Debugger_get_char();
+void Debugger_getline(char *);
+int Debugger_input_pending();
+void Debugger_Paint_Code_Lines( int );
+void Debugger_Status_Info();
+void Debugger_Open_Edit_Box();
+void dump_mem( unsigned char *, int);
+
+void Debugger_highlight_line(int );
+int is_at_start_of_line(unsigned char * p);
+void add_variable_to_display_list( unsigned char *);
+void dump_current_program_info( unsigned char *, int ); 
+
+void VT100_goto_xy(int, int );
+void VT100_Mouse_Mode_On();
+void VT100_Clear_Screen();
+void VT100_Clear_to_EOL();
+void VT100_Clear_Debugger_Screen();
+void VT100_all_attr_off();
+void VT100_bold_on();
+void VT100_low_intensity();
+void VT100_underline_on();
+void VT100_save_cursor();
+void VT100_restore_cursor();
+void VT100_forground_black();
+void VT100_forground_red();
+void VT100_forground_green();
+void VT100_forground_yellow();
+void VT100_forground_blue();
+void VT100_forground_cyan();
+void VT100_forground_magenta();
+void VT100_forground_white();
+void VT100_forground_grey();
+
+void VT100_background_black();
+void VT100_background_red() ;
+void VT100_background_green();
+void VT100_background_yellow();
+void VT100_background_blue();
+void VT100_background_cyan();
+void VT100_background_magenta();
+void VT100_background_white();
+void VT100_background_grey();
+
+void setup_terminal_screen_to_145x45(void);
+
+unsigned char *LocateProgramStatement( int );
+int  Debug_CountLines(unsigned char *);
+void Debugger_find_special_cmds();
+void Debugger_find_variables_used_by_line( int );
+void Debugger_var_display();
+void Debugger_display_error_message(char *);
+void Debugger_Pause(int );
+
+
+void Debug_Info( char *, int );
+void Debug_Info_hex( char *, int );
+void Debug_Info_char( char *, unsigned char);
+
+#endif
+
+
+
+
+/**********************************************************************************
+ All command tokens tokens (eg, PRINT, FOR, etc) should be inserted in this table
+**********************************************************************************/
+#ifdef INCLUDE_COMMAND_TABLE
+// the format is:
+//    TEXT      	TYPE                P  FUNCTION TO CALL
+// where type is always T_CMD
+// and P is the precedence (which is only used for operators and not commands)
+
+//	{ (unsigned char *)"Memory",		T_CMD,				0, cmd_memory	},
+
+#endif
+
+
+/**********************************************************************************
+ All other tokens (keywords, functions, operators) should be inserted in this table
+**********************************************************************************/
+#ifdef INCLUDE_TOKEN_TABLE
+// the format is:
+//    TEXT      	TYPE                P  FUNCTION TO CALL
+// where type is T_NA, T_FUN, T_FNA or T_OPER argumented by the types T_STR and/or T_NBR
+// and P is the precedence (which is only used for operators)
+
+#endif
+
+
+#if !defined(INCLUDE_COMMAND_TABLE) && !defined(INCLUDE_TOKEN_TABLE)
+// General definitions used by other modules
+
+#ifndef DEBUG_HEADER
+#define DEBUG_HEADER
+#endif
+#endif
+

--- a/PicoMite/Editor.h
+++ b/PicoMite/Editor.h
@@ -68,6 +68,7 @@ extern int editactive;
 #define NUM_ENT   ENTER
 #define SLOCK     0x8c
 #define ALT       0x8b
+#define MOUSE_CLICK 0x8c
 
 
 // definitions related to setting the tab spacing

--- a/PicoMite/MMBasic.h
+++ b/PicoMite/MMBasic.h
@@ -185,7 +185,9 @@ extern const char upper[256];
 
 extern int CommandTableSize, TokenTableSize;
 
-extern volatile int MMAbort;
+extern volatile int MMAbort, MMDebug, MMDebug_Level_Change;
+extern unsigned char *MMDebug_Brk_Pnt_Addr;;
+
 extern jmp_buf mark;                            // longjump to recover from an error
 extern unsigned char BreakKey;                           // console break key (defaults to CTRL-C)
 extern jmp_buf jmprun;

--- a/PicoMite/PicoMite.c
+++ b/PicoMite/PicoMite.c
@@ -84,12 +84,13 @@ int ListCnt;
 int MMCharPos;
 int busfault=0;
 int ExitMMBasicFlag = false;
-volatile int MMAbort = false;
+volatile int MMAbort = false, MMDebug=false, MMDebug_Level_Change=-1;
 unsigned int _excep_peek;
 void CheckAbort(void);
 void TryLoadProgram(void);
 unsigned char lastchar=0;
 unsigned char BreakKey = BREAK_KEY;                                          // defaults to CTRL-C.  Set to zero to disable the break function
+unsigned char DebugKey = DEBUG_KEY;                                          // defaults to CTRL-D.  Set to zero to disable the MMDebug feature
 volatile char ConsoleRxBuf[CONSOLE_RX_BUF_SIZE]={0};
 volatile int ConsoleRxBufHead = 0;
 volatile int ConsoleRxBufTail = 0;
@@ -292,6 +293,12 @@ void __not_in_flash_func(routinechecks)(void){
     if(tud_cdc_connected() && (Option.SerialConsole==0 || Option.SerialConsole>4) && Option.Telnet!=-1){
         while(( c=tud_cdc_read_char())!=-1){
             ConsoleRxBuf[ConsoleRxBufHead] = c;
+
+            if (DebugKey && c == DebugKey /* defaults to Ctrl-D */) {   // if the user wants to enter the debugger
+                MMDebug = true;                                         // set the flag that happened
+                ConsoleRxBufHead = ConsoleRxBufTail;                    // empty the buffer
+            } 
+
             if(BreakKey && ConsoleRxBuf[ConsoleRxBufHead] == BreakKey) {// if the user wants to stop the progran
                 MMAbort = true;                                        // set the flag for the interpreter to see
                 ConsoleRxBufHead = ConsoleRxBufTail;                    // empty the buffer

--- a/PicoMite/configuration.h
+++ b/PicoMite/configuration.h
@@ -110,13 +110,14 @@ extern "C" {
 #endif
 #define MAXPROMPTLEN        49                      // max length of a prompt incl the terminating null
 #define BREAK_KEY           3                       // the default value (CTRL-C) for the break key.  Reset at the command prompt.
+#define DEBUG_KEY           4                       // the default value (CTRL-D) for the debug key.  Reset at the command prompt.
 #define FNV_prime           16777619
 #define FNV_offset_basis    2166136261
 #define use_hash
 #define DISKCHECKRATE       500                    //check for removal of SDcard every 200mSec
 #define EDIT_BUFFER_SIZE    HEAP_MEMORY_SIZE-2048-3*HRes// this is the maximum RAM that we can get
-#define SCREENWIDTH     80
-#define SCREENHEIGHT    24                          // this is the default and it can be changed using the OPTION command
+#define SCREENWIDTH     145
+#define SCREENHEIGHT    45                          // this is the default and it can be changed using the OPTION command
 #define CONSOLE_BAUDRATE        115200               // only applies to the serial console
 #define MAXCFUNCTION	20
 #define SAVEDVARS_FLASH_SIZE 16384


### PR DESCRIPTION
All of the changes required to add the MMDebug functionality to the PicoMite firmware.

None of this functionality affects the main PicoMite functionality until the user presses Ctrl-D.    

I generic Copy Right headers in place, but I don't care about any Copy Right.   That can be changed however you feel it should be.

The MMDebug window size is hard coded at the moment.   That will be cleaned up and made to be easily adjustable by the user.

If this can be merged into the main PicoMite firmware base, it will be much easier for me to support it and address any bug fixes that need to be done.
